### PR TITLE
Bug Fixing the next option skip in some tags

### DIFF
--- a/src/lib/components/common/PreviousNextButton/PreviousNextButton.jsx
+++ b/src/lib/components/common/PreviousNextButton/PreviousNextButton.jsx
@@ -116,8 +116,9 @@ function PreviousNextButton(props) {
       let prevPathValue = '';
       let nextPathValue = '';
       tags.map((res, index) => {
-        if (_.startsWith(res.name, currentPathValue[0]) &&
-          _.endsWith(res.name, currentPathValue[currentPathValue.length - 1]) &&
+        let pathArray = res.name.split('/');
+        if (pathArray[0] === currentPathValue[0] &&
+          pathArray[pathArray.length - 1] === currentPathValue[currentPathValue.length - 1] &&
           _.endsWith(res.name, activeTag)) {
           setCurrentPath(res.name);
           currentIndex = index;
@@ -183,7 +184,7 @@ function PreviousNextButton(props) {
       }
 
       return store.dispatch(OpenAPIActions.load('http://localhost:4000/api/logistics1', tag));
-      // return store.dispatch(OpenAPIActions.load('http://1984d848.ngrok.io/api/logistics1', tag));
+      // return store.dispatch(OpenAPIActions.load('http://af34d848.ngrok.io/api/logistics1', tag));
     }
   }
 

--- a/src/lib/components/common/Sidebar/Sidebar.jsx
+++ b/src/lib/components/common/Sidebar/Sidebar.jsx
@@ -131,8 +131,9 @@ function Sidebar(props) {
     if (activeTag && currentPathValue && currentPathValue.length > 0 && tags) {
       let currentPath = ''
       tags.map((res, index) => {
-        if (_.startsWith(res.name, currentPathValue[0]) &&
-          _.endsWith(res.name, currentPathValue[currentPathValue.length - 1]) &&
+        let pathArray = res.name.split('/');
+        if (pathArray[0] === currentPathValue[0] &&
+          pathArray[pathArray.length - 1] === currentPathValue[currentPathValue.length - 1] &&
           _.endsWith(res.name, activeTag)) {
           currentPath = res.name;
         }
@@ -194,7 +195,7 @@ function Sidebar(props) {
         props.currentIdSideBar(value.randomId);
       }
       return store.dispatch(OpenAPIActions.load('http://localhost:4000/api/logistics1', value.tag))
-      // return store.dispatch(OpenAPIActions.load('http://1984d848.ngrok.io/api/logistics1', tag))
+      // return store.dispatch(OpenAPIActions.load('http://af34d848.ngrok.io/api/logistics1', value.tag))
     }
 
   }
@@ -203,8 +204,8 @@ function Sidebar(props) {
     e.preventDefault();
     e.stopPropagation();
     let key = ''
-    if (tag && tag.hasOwnProperty('key')) {
-      key = tag.key
+    if (tag && tag.hasOwnProperty('randomId')) {
+      key = tag.randomId
     } else {
       key = tag
     }
@@ -231,7 +232,7 @@ function Sidebar(props) {
     } else {
       return (<ul className={s["level" + level]}>
         {nodes.map((node, index) => {
-          return <li key={node.tag} className={currentTag === node.tag ? s.nodeActive : s.node}>
+          return <li key={node.tag} className={currentActiveId === node.randomId ? s.nodeActive : s.node}>
             <TreeIcon hasChildren={node.nodes.length > 0} opened={node.opened} node={node} key={index}></TreeIcon> <span
               className={s.label} onClick={(e) => loadApi(e, node)}> {node.key} </span>
             {node.opened ? <ChildNode nodes={node.nodes} level={level + 1}></ChildNode> : null}
@@ -307,7 +308,7 @@ function Sidebar(props) {
         </div>
         <ul className={"level1"} id={s.listText}>
           {sidebar && sidebar.tags && sidebar.tags.length > 0 && sidebar.tags.map((tag, index) => {
-            return <li key={tag.tag} className={currentTag === tag.tag ? s.nodeActive : s.node}>
+            return <li key={tag.tag} className={currentActiveId === tag.randomId ? s.nodeActive : s.node}>
               <TreeIcon hasChildren={tag.nodes.length > 0} opened={tag.opened} node={tag} key={index}></TreeIcon>
               <span className={s.label} onClick={(e) => loadApi(e, tag)}> {tag.key} </span>
               {tag.opened ? <ChildNode nodes={tag.nodes} level={level + 1}></ChildNode> : null}

--- a/src/lib/components/openapi/ParentPath/ParentPath.jsx
+++ b/src/lib/components/openapi/ParentPath/ParentPath.jsx
@@ -203,6 +203,7 @@ function ParentPath(props) {
         e.stopPropagation();
       }
       return store.dispatch(OpenAPIActions.load('http://localhost:4000/api/logistics1', data.tag))
+      // return store.dispatch(OpenAPIActions.load('http://af34d848.ngrok.io/api/logistics1', data.tag))
     } else {
       setParentTagCheck(!parentTagCheck);
     }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -19,4 +19,4 @@ ReactDOM.render(app, document.getElementsByClassName('main')[0]);
 // Load spec & tags
 // store.dispatch(OpenAPIActions.loadTags('http://localhost:4000/tags/petstore'));
 store.dispatch(OpenAPIActions.loadTags('http://localhost:4000/tags/logistics1'));
-// store.dispatch(OpenAPIActions.loadTags('http://1984d848.ngrok.io/tags/logistics1'));
+// store.dispatch(OpenAPIActions.loadTags('http://af34d848.ngrok.io/tags/logistics1'));

--- a/src/reducers/OpenAPIReducer.js
+++ b/src/reducers/OpenAPIReducer.js
@@ -53,7 +53,7 @@ export default handleActions({
         let tags = state.getIn(['sidebar', 'tags']).toJS();
 
         function checkToggle(t) {
-            if (t.key === action.payload) {
+            if (t.randomId === action.payload) {
                 t.opened = !t.opened;
             } else if (t.nodes.length > 0) {
                 t.nodes.map(checkToggle);

--- a/src/screens/App/App.jsx
+++ b/src/screens/App/App.jsx
@@ -49,7 +49,7 @@ function App(props) {
   function loadApi(tag) {
     if (tag) {
       return store.dispatch(OpenAPIActions.load('http://localhost:4000/api/logistics1', tag));
-      // return store.dispatch(OpenAPIActions.load('http://1984d848.ngrok.io/api/logistics1', tag));
+      // return store.dispatch(OpenAPIActions.load('http://af34d848.ngrok.io/api/logistics1', tag));
     }
   }
 


### PR DESCRIPTION
Bugs fixed:
- In the Consols sidebar tag, When clicking the next option, it is not working until we open the sub-tag.
- When using the next arrow from Items sidebar Tags it skips 8 node tags & loads to the 9th node tags.
- When using the next arrow from Locations sidebar Tags it skips 8 node tags & loads to the 10th node tags.